### PR TITLE
Revert Chef Server version back to 11.0.4-1 and knife command reorder

### DIFF
--- a/chef-install/install-chef-server.sh
+++ b/chef-install/install-chef-server.sh
@@ -42,7 +42,7 @@ if [ "$(uname -p)" != "x86_64" ]; then
     exit 1
 fi
 
-CHEF_SERVER_VERSION=${CHEF_SERVER_VERSION:-11.0.8-1}
+CHEF_SERVER_VERSION=${CHEF_SERVER_VERSION:-11.0.4-1}
 
 if [[ $OS_TYPE = "ubuntu" ]]; then
     apt-get update -y --force-yes
@@ -117,7 +117,7 @@ EOF
     chown -R ${CHEF_UNIX_USER}: ${HOMEDIR}/.chef
 
     if [[ ! -e ${HOMEDIR}/.chef/knife.rb ]]; then
-       cat <<EOF | /opt/chef-server/embedded/bin/knife configure -i
+       cat <<EOF | /opt/chef-server/bin/knife configure -i
 ${HOMEDIR}/.chef/knife.rb
 ${CHEF_URL}
 admin

--- a/chef-install/install-cookbooks.sh
+++ b/chef-install/install-cookbooks.sh
@@ -64,8 +64,8 @@ git checkout ${COOKBOOK_BRANCH}
 git submodule init
 git submodule update
 
-knife role from file roles/*.rb
 knife cookbook upload -a -o cookbooks
+knife role from file roles/*.rb
 
 popd
 


### PR DESCRIPTION
A pull request was applied last week updating the Chef Server version downloaded to 11.0.8-1. This new version of Chef Server introduces additional parameters that the script does not account for thus breaking installation. I recommend reverting back to the tried and true 11.0.4-1 version until further testing can be done against 11.0.8-1.

Also changing the order of two knife commands to match the corresponding documentation.
