### PR TITLE
Fix for .bash_profile not being created

### DIFF
--- a/chef-install/install-chef-server.sh
+++ b/chef-install/install-chef-server.sh
@@ -125,7 +125,7 @@ chef-validator
 ${HOMEDIR}/.chef/chef-validator.pem
 EOF
         # setup the path
-        sed -i '/export PATH=${PATH}:\/opt\/chef-server\/bin/d' ${HOMEDIR}/.bash_profile
+        sed -i '/export PATH=${PATH}:\/opt\/chef-server\/bin/d' ${HOMEDIR}/.bash_profile || true
         echo 'export PATH=${PATH}:/opt/chef-server/embedded/bin' >> ${HOMEDIR}/.bash_profile
         export OLDPATH=${PATH}
     fi


### PR DESCRIPTION
If the .bash_profile does not exist, the sed command to delete the old chef-server bin path is failing causing the .bash_profile to not be created. Appending true to the sed command fixes this.
