### PR TITLE
Fix $PATH handling without relying on sourcing mechanics

### DIFF
--- a/chef-install/install-chef-server.sh
+++ b/chef-install/install-chef-server.sh
@@ -125,18 +125,11 @@ chef-validator
 ${HOMEDIR}/.chef/chef-validator.pem
 EOF
         # setup the path
-        sed -i '/export PATH=${PATH}:\/opt\/chef-server\/bin/d' ${HOMEDIR}/.bash_profile
+        sed -i '/export PATH=${PATH}:\/opt\/chef-server\/bin/d' ${HOMEDIR}/.bash_profile || true
         echo 'export PATH=${PATH}:/opt/chef-server/embedded/bin' >> ${HOMEDIR}/.bash_profile
-        export OLDPATH=${PATH}
+        export OLDPATH=${OLDPATH:-$PATH}
     fi
 
     # these are only returned on a run where we actually install chef-server
-
-    export PATH=${OLDPATH:-$PATH}
-    source ${HOMEDIR}/.bash_profile
-
-    # attempt to reload cookbooks/roles/environment, don't bomb if these fail
-    knife cookbook upload -o ${HOMEDIR}/chef-cookbooks/cookbooks -a || true
-    knife role from_file ${HOMEDIR}/chef-cookbooks/roles/*.rb || true
-    knife environment from_file ${ENVFILE:-env.json} || true
+    export PATH=${OLDPATH:-$PATH}:/opt/chef-server/embedded/bin
 fi


### PR DESCRIPTION
This also removes the automatic cookbook/role/environment uploads, as they should be decoupled from this script.
