### PR TITLE
Added a post deployment tools directory

### DIFF
--- a/post-deployment-tools/README.rst
+++ b/post-deployment-tools/README.rst
@@ -40,10 +40,8 @@ Tools
     of the neutron network. When the script is complete, the built instance(s) will be 
     removed. All output for the scirpt is printed to stdout in a human readable format.
     
+    Usage: 
+    
     .. code-block:: bash
     
         bash neutron_network_test.sh
-        
-
-        
-        

--- a/post-deployment-tools/README.rst
+++ b/post-deployment-tools/README.rst
@@ -1,0 +1,49 @@
+Tools used for in POST deployment
+#################################
+:date: 2014-04-02
+:tags: rackspace, private cloud, qc
+:category: \*nix
+
+
+The tools within this directory were created to allow you to more rapidly 
+ensure that the deployment is setup and working as expected. 
+
+Tools
+-----
+
+*   ``keystone_user_create.sh``
+
+    This tool was created to allow you to create users, tenants and roles for a 
+    new deployment more rapidly
+    
+    Usage: 
+    
+    .. code-block:: bash
+    
+        export USER_NAME="new_user_name"
+        export TENANT_NAME="new_tenant_name"
+        export ROLE_NAME="new_role_name"
+        
+        bash keystone_user_create.sh
+
+ 
+    When running the script, if a role is set that does not exist it will be created. 
+    the script assumes that you have no conflicting usernames, tenant names, or role 
+    names. When the script has completed an openrc-customer-$NAME will be saved in the
+    current working directory. 
+    
+*   ``neutron_network_test.sh``
+
+    This tool was created to allow you to test that all of the created neutron networks
+    working as expected.  This is a test script that will build 1 instance per network 
+    and will then attempt to ping the network gateway from within the network namespace
+    of the neutron network. When the script is complete, the built instance(s) will be 
+    removed. All output for the scirpt is printed to stdout in a human readable format.
+    
+    .. code-block:: bash
+    
+        bash neutron_network_test.sh
+        
+
+        
+        

--- a/post-deployment-tools/keystone_user_create.sh
+++ b/post-deployment-tools/keystone_user_create.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Generating new Keystone Users 
+
+# Variables:
+#   TENANT_NAME=The name of an existing tenat that we will get the role from,
+#               defaults to "demo".
+#   USER_NAME=Set the name of the new Keystone User, will default to tenant
+#             if not already created.
+#   ROLE_NAME=The name of an existing role which your new user will be bound to.
+#   PASSWD=Set the password, if not set it will be generated.
+
+set -e -u
+
+if [ ! -f "$(pwd)/openrc" ];then
+  echo "No OpenRC File found in $(pwd)"
+  exit 1
+else
+  source openrc
+fi
+
+TENANT_NAME=${TENANT_NAME:-"demo"}
+USER_NAME=${USER_NAME:-$TENANT_NAME}
+ROLE_NAME=${ROLE_NAME:-"demo"}
+PASSWD=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 32)
+
+# Get the role from a provided 
+echo "Checking for role"
+ROLE_ID=$(keystone role-list | grep -w ${ROLE_NAME} | awk '{print $2}')
+if [[ -z "${ROLE_ID}" ]];then
+  echo "Creating Role ${ROLE_NAME}"
+  ROLE_ID=$(keystone role-create --name ${ROLE_NAME} | awk '/id/ {print $4}')
+fi
+
+# Creating the new tenant
+echo "Creating Tenant ${TENANT_NAME}"
+NEW_TENANT_ID=$(keystone tenant-create --name ${TENANT_NAME} | awk '/id/ {print $4}')
+
+# Create the new User
+echo "Creating User ${USER_NAME}"
+USER_ID=$(keystone user-create --name ${USER_NAME} \
+                               --pass ${PASSWD} \
+                               --tenant_id ${NEW_TENANT_ID} \
+                               --enabled true | awk '/id/ {print $4}')
+
+# Creating the new user role
+echo "Granting User ${USER_NAME} with Tenant ${TENANT_NAME} access to Role ${ROLE_NAME}"
+keystone user-role-add --user_id ${USER_ID} \
+                       --role_id ${ROLE_ID} \
+                       --tenant_id ${NEW_TENANT_ID}
+
+echo -e "
+--------------------------------------
+Here is the password, WRITE THIS DOWN!
+--------------------------------------
+Username: ${USER_NAME}
+Tenant Name: ${TENANT_NAME}
+Password: ${PASSWD}
+"
+
+cat > $(pwd)/openrc-customer2 <<EOF
+# CUSTOMER OPENSTACK ENVS
+export OS_USERNAME=${USER_NAME}
+export OS_PASSWORD=${PASSWD}
+export OS_TENANT_NAME=${TENANT_NAME}
+export OS_AUTH_URL=${OS_AUTH_URL}
+export OS_AUTH_STRATEGY=keystone
+export OS_NO_CACHE=1
+EOF

--- a/post-deployment-tools/keystone_user_create.sh
+++ b/post-deployment-tools/keystone_user_create.sh
@@ -70,7 +70,7 @@ Tenant Name: ${TENANT_NAME}
 Password: ${PASSWD}
 "
 
-cat > $(pwd)/openrc-customer2 <<EOF
+cat > $(pwd)/openrc-customer-${USER_NAME} <<EOF
 # CUSTOMER OPENSTACK ENVS
 export OS_USERNAME=${USER_NAME}
 export OS_PASSWORD=${PASSWD}

--- a/post-deployment-tools/neutron_network_test.sh
+++ b/post-deployment-tools/neutron_network_test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test an attach neutron network and ping the Gateway
+# This script will build 1 instance per network then it will ping the 
+# Network gateway from within the network namespace.
+
+# Variables:
+#   FLAVOR=The flavor size ID, defaults to 2.
+#   IMAGE=Image ID, defaults to the first found image ID.
+#   KEYNAME=Name of a keypair, defaults to "PrivateCloudTest".
+
+
+if [ ! -f "/tmp/test-key" ];then
+  ssh-keygen -t rsa -f /tmp/test-key -N ''
+fi
+
+if [ ! -f "$(pwd)/openrc" ];then
+  echo "No OpenRC File found"
+  exit 1
+else
+  source openrc
+fi
+
+BASE_IMAGE="$(nova image-list | awk '/ACTIVE/ {print $2}' | head -n 1)"
+
+FLAVOR=${FLAVOR:-2}
+IMAGE=${IMAGE:-${BASE_IMAGE}}
+KEYNAME=${KEYNAME:-"PrivateCloudTest"}
+
+
+echo "Creating Key"
+if [ ! "$(nova keypair-list | grep ${KEYNAME})" ];then
+  nova keypair-add PrivateCloudTest --pub-key /tmp/test-key.pub
+fi
+
+
+echo "Creating Servers"
+for i in $(neutron net-list | awk '{print $2}' | grep -v id)
+  do 
+    nova boot --image=${IMAGE} \
+              --flavor=${FLAVOR} \
+              --key-name=PrivateCloudTest \
+              --nic net-id=$i \
+              $i-PrivateCloudTest > /dev/null \
+                && echo BUILD SUCCESS $i || echo BUILD FAIL "$i"
+done
+sleep 5
+
+
+echo "Testing Networks"
+for i in $(ip netns | grep qdhcp)
+  do 
+    GW=$(ip netns exec $i ip r | awk '/default/ {print $3}')
+    (ip netns exec $i ping -c 2 ${GW} > /dev/null \
+      && echo PING SUCCESS "$i" "${GW}") || echo PING FAIL "$i" "${GW}"
+done
+
+echo "Removing Test KeyPair"
+nova keypair-delete ${KEYNAME}
+
+echo "Removing Testing Instances"
+for i in $(nova list | awk '/PrivateCloudTest/ {print $2}')
+  do
+    nova delete $i
+done


### PR DESCRIPTION
When deploying Openstack, as support does, support has nearly 70 things that they need to do to post QC the deployment.  This directory was added to create a collection of scripts that automate most of those tasks.

Adds: 
- Keystone user create script
- Neutron network test script
