### PR TITLE
Change file check order

### DIFF
--- a/chef-install/install-chef-server.sh
+++ b/chef-install/install-chef-server.sh
@@ -25,13 +25,13 @@ pwgen() {
     tr -dc A-Za-z0-9_ < /dev/urandom | head -c ${l} | xargs
 }
 
-if [ -e /etc/lsb-release ]; then
+if [ -f "/etc/system-release-cpe" ]; then
+    OS_TYPE=$(cat /etc/system-release-cpe | cut -d ":" -f 3)
+    OS_VER=6
+elif [ -e /etc/lsb-release ]; then
     source /etc/lsb-release
     OS_TYPE=${DISTRIB_ID~}
     OS_VER=${DISTRIB_RELEASE}
-elif [ -f "/etc/system-release-cpe" ]; then
-    OS_TYPE=$(cat /etc/system-release-cpe | cut -d ":" -f 3)
-    OS_VER=6
 else
     echo "Cannot determine operating system"
     exit 1


### PR DESCRIPTION
The `/etc/lsb-release` file exists on CentOS 6.5, too. Switching the order of this check allows for both Ubuntu and CentOS's Chef Server installation to succeed since `/etc/system-release-cpe` is exclusive to the latter.

Tested with Monster's `pubcloud-neutron` configuration on Grizzly with both Ubuntu and CentOS.
